### PR TITLE
Add list of sicknesses and fetching of an employee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog]
 
+[0.3.0]
+
+- Allow listing of sicknesses
+- Allow listing of employees and fetching a single employee
+
 [0.1.2]
 
 - Raise an error when API key is incorrect

--- a/README.md
+++ b/README.md
@@ -38,10 +38,35 @@ client = Breathe::Client.new(api_key: YOUR_API_KEY)
 
 And use like so
 
+### List absences (Holiday and Other leave)
+
 ```ruby
 client.absences.list
 #=> [...]
 ```
+
+### List sicknesses
+
+```ruby
+client.sicknesses.list
+#=> [...]
+```
+
+### List employees
+
+```ruby
+client.employees.list
+#=> [...]
+```
+
+### Get an employee by ID
+
+```ruby
+client.employees.get(id)
+#=> [...]
+```
+
+### Filtering
 
 You can also pass in arguments like so:
 

--- a/lib/breathe.rb
+++ b/lib/breathe.rb
@@ -5,6 +5,7 @@ require "breathe/client"
 require "breathe/response"
 
 require "breathe/absences"
+require "breathe/sicknesses"
 
 module Breathe
   class Error < StandardError; end

--- a/lib/breathe.rb
+++ b/lib/breathe.rb
@@ -6,6 +6,7 @@ require "breathe/response"
 
 require "breathe/absences"
 require "breathe/sicknesses"
+require "breathe/employees"
 
 module Breathe
   class Error < StandardError; end

--- a/lib/breathe/client.rb
+++ b/lib/breathe/client.rb
@@ -17,9 +17,13 @@ module Breathe
       @sicknesses ||= Sicknesses.new(self)
     end
 
-    def response(method:, path:, args:)
+    def employees
+      @employees ||= Employees.new(self)
+    end
+
+    def response(method:, path:, args: {})
       response = request(method: method, path: path, options: {query: args})
-      parsed_response = Response.new(response: response, type: path)
+      parsed_response = Response.new(response: response, type: path.split("/").first)
 
       if parsed_response.success?
         @auto_paginate ? auto_paginated_response(parsed_response) : parsed_response

--- a/lib/breathe/client.rb
+++ b/lib/breathe/client.rb
@@ -13,6 +13,10 @@ module Breathe
       @absences ||= Absences.new(self)
     end
 
+    def sicknesses
+      @sicknesses ||= Sicknesses.new(self)
+    end
+
     def response(method:, path:, args:)
       response = request(method: method, path: path, options: {query: args})
       parsed_response = Response.new(response: response, type: path)

--- a/lib/breathe/employees.rb
+++ b/lib/breathe/employees.rb
@@ -1,0 +1,24 @@
+module Breathe
+  class Employees
+    attr_reader :client
+
+    def initialize(client)
+      @client = client
+    end
+
+    def list(args = {})
+      client.response(
+        method: :get,
+        path: "employees",
+        args: args
+      )
+    end
+
+    def get(id)
+      client.response(
+        method: :get,
+        path: "employees/#{id.to_i}"
+      )
+    end
+  end
+end

--- a/lib/breathe/sicknesses.rb
+++ b/lib/breathe/sicknesses.rb
@@ -1,0 +1,17 @@
+module Breathe
+  class Sicknesses
+    attr_reader :client
+
+    def initialize(client)
+      @client = client
+    end
+
+    def list(args = {})
+      client.response(
+        method: :get,
+        path: "sicknesses",
+        args: args
+      )
+    end
+  end
+end

--- a/lib/breathe/version.rb
+++ b/lib/breathe/version.rb
@@ -1,3 +1,3 @@
 module Breathe
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/breathe/employees_spec.rb
+++ b/spec/breathe/employees_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+RSpec.describe Breathe::Employees do
+  let(:client) { Breathe::Client.new(api_key: breathe_api_key) }
+  let(:breathe_api_key) { "foo" }
+
+  describe "#list" do
+    context "without any arguments" do
+      let(:employees) { described_class.new(client).list }
+      before { stub_employees_list }
+
+      it "returns all employees" do
+        expect(employees.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees")
+      end
+
+      it "gets the next page" do
+        stub_employees_list("?page=2")
+
+        next_page = employees.next_page
+        expect(next_page.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees")
+          .with(query: {"page" => "2"})
+      end
+
+      it "gets the last page" do
+        stub_employees_list("?page=22")
+
+        last_page = employees.last_page
+        expect(last_page.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees")
+          .with(query: {"page" => "22"})
+      end
+    end
+
+    context "with a per_page argument" do
+      let(:employees) { described_class.new(client).list(per_page: 10) }
+      before { stub_employees_list("?per_page=10") }
+
+      it "returns the expected number of employees" do
+        expect(employees.count).to eq(1)
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees")
+          .with(query: {"per_page" => "10"})
+      end
+    end
+
+    context "with a page argument" do
+      let(:employees) { described_class.new(client).list(page: 2) }
+      before { stub_employees_list("?page=2") }
+
+      it "makes the expected request" do
+        employees
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees")
+          .with(query: {"page" => "2"})
+      end
+    end
+  end
+
+  describe "#get" do
+    let(:get_employee) { described_class.new(client).get(id) }
+    let(:id) { "123" }
+    before { stub_employees_get(id) }
+
+    it "returns a specific employee by id" do
+      expect(get_employee.count).to eq(1)
+
+      expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/employees/123")
+    end
+  end
+
+  def stub_employees_list(query_string = "")
+    stub_request(:get, "https://api.breathehr.com/v1/employees#{query_string}")
+      .to_return(
+        body: JSON.parse(File.read(File.join("spec", "fixtures", "employees.json"))).to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Api-Key" => breathe_api_key,
+          "Link" => "<https://api.breathehr.com/v1/employees?page=1>; rel=\"first\", <https://api.breathehr.com/v1/employees?page=1>; rel=\"prev\", <https://api.breathehr.com/v1/employees?page=22>; rel=\"last\", <https://api.breathehr.com/v1/employees?page=2>; rel=\"next\"",
+        }
+      )
+  end
+
+  def stub_employees_get(id)
+    stub_request(:get, "https://api.breathehr.com/v1/employees/#{id}")
+      .to_return(
+        body: JSON.parse(File.read(File.join("spec", "fixtures", "employees.json"))).to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Api-Key" => breathe_api_key,
+        }
+      )
+  end
+end

--- a/spec/breathe/sicknesses_spec.rb
+++ b/spec/breathe/sicknesses_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+RSpec.describe Breathe::Sicknesses do
+  let(:client) { Breathe::Client.new(api_key: breathe_api_key) }
+  let(:breathe_api_key) { "foo" }
+
+  describe "#list" do
+    context "without any arguments" do
+      let(:sicknesses) { described_class.new(client).list }
+      before { stub_sicknesses_list }
+
+      it "returns all sicknesses" do
+        expect(sicknesses.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+      end
+
+      it "gets the next page" do
+        stub_sicknesses_list("?page=2")
+
+        next_page = sicknesses.next_page
+        expect(next_page.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+          .with(query: {"page" => "2"})
+      end
+
+      it "gets the last page" do
+        stub_sicknesses_list("?page=22")
+
+        last_page = sicknesses.last_page
+        expect(last_page.count).to eq(1)
+
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+          .with(query: {"page" => "22"})
+      end
+    end
+
+    context "with a per_page argument" do
+      let(:sicknesses) { described_class.new(client).list(per_page: 10) }
+      before { stub_sicknesses_list("?per_page=10") }
+
+      it "returns the expected number of sicknesses" do
+        expect(sicknesses.count).to eq(1)
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+          .with(query: {"per_page" => "10"})
+      end
+    end
+
+    context "with a page argument" do
+      let(:sicknesses) { described_class.new(client).list(page: 2) }
+      before { stub_sicknesses_list("?page=2") }
+
+      it "makes the expected request" do
+        sicknesses
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+          .with(query: {"page" => "2"})
+      end
+    end
+
+    context "with filtering" do
+      let(:date) { "2019-11-01" }
+      let(:sicknesses) { described_class.new(client).list(start_date: Date.parse(date), end_date: date) }
+      before { stub_sicknesses_list("?start_date=#{date}&end_date=#{date}") }
+
+      it "makes the expected request" do
+        sicknesses
+        expect(WebMock).to have_requested(:get, "https://api.breathehr.com/v1/sicknesses")
+          .with(query: {"start_date" => date, "end_date" => date})
+      end
+    end
+  end
+
+  def stub_sicknesses_list(query_string = "")
+    stub_request(:get, "https://api.breathehr.com/v1/sicknesses#{query_string}")
+      .to_return(
+        body: JSON.parse(File.read(File.join("spec", "fixtures", "sicknesses.json"))).to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-Api-Key" => breathe_api_key,
+          "Link" => "<https://api.breathehr.com/v1/sicknesses?page=1>; rel=\"first\", <https://api.breathehr.com/v1/sicknesses?page=1>; rel=\"prev\", <https://api.breathehr.com/v1/sicknesses?page=22>; rel=\"last\", <https://api.breathehr.com/v1/sicknesses?page=2>; rel=\"next\"",
+        }
+      )
+  end
+end

--- a/spec/fixtures/employees.json
+++ b/spec/fixtures/employees.json
@@ -1,0 +1,30 @@
+{
+  "employees": [
+    {
+      "length_of_service_in_months": "",
+      "full_or_part_time": "",
+      "photo_url": "",
+      "working_pattern": "",
+      "line_manager": "",
+      "holiday_approver": "",
+      "department": "",
+      "division": "",
+      "location": "",
+      "job_start_date": "",
+      "job_title": "",
+      "id": "",
+      "account_id": "",
+      "first_name": "Clarke",
+      "middle_name": "",
+      "last_name": "Kent",
+      "email": "email@example.com",
+      "join_date": "",
+      "known_as": "",
+      "leaving_date": "",
+      "employee_ref": "",
+      "probation_date": "",
+      "created_at": "",
+      "updated_at": ""
+    }
+  ]
+}

--- a/spec/fixtures/sicknesses.json
+++ b/spec/fixtures/sicknesses.json
@@ -1,0 +1,25 @@
+{
+  "sicknesses": [
+    {
+      "company_sicknesstype": {
+        "id": 95160,
+        "name": "*Please set on return to work"
+      },
+      "employee": {
+        "id": 12345
+      },
+      "id": 111111,
+      "start_date": "2020-01-08",
+      "end_date": "2020-01-08",
+      "half_start": false,
+      "half_start_am_pm": null,
+      "half_end": false,
+      "half_end_am_pm": null,
+      "deducted": "1.0",
+      "status": "returned",
+      "reason": "",
+      "review_notes": null,
+      "fit_note_required": null
+    }
+  ]
+}


### PR DESCRIPTION
Sickness is treated differently to absences in BreatheHR and the email address associated with the staff member is not provided in the dataset.

In order to make the correct assignment in 10kft we need to know the email address associated with the staff member and make another call to the employee endpoint.