### PR TITLE
Add contributing-related documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+The [dxw standard contributing guide](https://github.com/dxw/.github/blob/main/CONTRIBUTING.md) applies for this repository.


### PR DESCRIPTION
These files are required by [dxw tech team RFC 28](https://github.com/dxw/tech-team-rfcs/blob/master/rfc-028-adopt-a-code-of-conduct.md). The content is taken from dxw/.github@002ebd0cfe8862e741de64b9b6ee675d2eced840.

This pull request was generated by dxw’s [repo-audit](https://github.com/dxw/repo-audit).
