### PR TITLE
Log HTTP status code and raw JSON if an unexpected error occurs

### DIFF
--- a/lib/breathe/response.rb
+++ b/lib/breathe/response.rb
@@ -45,6 +45,9 @@ module Breathe
       when 401
         raise Breathe::AuthenticationError, "The BreatheHR API returned a 401 error - are you sure you've set the correct API key?"
       else
+        puts("Unknown Error")
+        puts(response.status)
+        puts(response.body)
         raise Breathe::UnknownError, "The BreatheHR API returned an unknown error"
       end
     end

--- a/spec/breathe/response_spec.rb
+++ b/spec/breathe/response_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Breathe::Response do
     end
 
     context "when response is a 500" do
-      let(:sawyer_response) { double("Sawyer::Response", status: 500) }
+      let(:sawyer_response) { double("Sawyer::Response", status: 500, body: '{"error": "bad"}') }
 
       it "raises an error" do
         expect { subject }.to raise_error(


### PR DESCRIPTION
Whilst trying to diagnose issues with the redacted client, we discovered a need to be able to get the error messages out somehow.