### PR TITLE
v0.3.5: optional directory creation on push to ruby gems

### DIFF
--- a/.github/setup-rubygems.sh
+++ b/.github/setup-rubygems.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-mkdir ~/.gem
+mkdir -p ~/.gem
 echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials

--- a/lib/breathe/version.rb
+++ b/lib/breathe/version.rb
@@ -1,3 +1,3 @@
 module Breathe
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end


### PR DESCRIPTION
Push to ruby gems failed with 
```
Run bash .github/setup-rubygems.sh
mkdir: cannot create directory ‘/home/runner/.gem’: File exists
Error: Process completed with exit code 1.
```