### PR TITLE
Allow use of alternative API

### DIFF
--- a/lib/breathe/client.rb
+++ b/lib/breathe/client.rb
@@ -2,7 +2,7 @@ module Breathe
   class Client
     attr_reader :api_key, :last_response
 
-    BASE_URL = "https://api.breathehr.com/v1/"
+    BASE_URL = ENV.fetch("BREATHE_API_URL", "https://api.breathehr.com/v1/")
 
     def initialize(api_key:, auto_paginate: false)
       @api_key = api_key


### PR DESCRIPTION
The `BREATHE_API_URL` environment variable can be set to redirect requests to a different server such as one provided by
https://github.com/dxw/breathe-redacted-api . (If unset, it remains pointing at the official Breathe API)